### PR TITLE
use host user id optional arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,10 @@ RUN apt-get update \
   && pip3 --no-cache-dir install --upgrade pip \
   && rm -rf /var/lib/apt/lists/*
 
-# TODO: add build arg to pass in user id other than 1000
-RUN useradd --create-home --user-group --uid 1000 node
+# The host machine must have a user with the uid used here, therefore the uid should be
+# provided as an arg.  Default is uid 1000.
+ARG hostUserId
+RUN if [ "$hostUserId" = "" ] ; then useradd --create-home --user-group --uid 1000 node ; else useradd --create-home --user-group --uid $hostUserId node ; fi
 
 USER node
 RUN mkdir -p /home/node/.cache


### PR DESCRIPTION
Made changes in Dockerfile (this PR) and docker-compose.yml (platform PR) to support passing an optional CL arg HOST_UID when running 'docker-compose up':

 _HOST_UID=1001 docker-compose up -d_

I also added the permission denied error and solution to Coda: https://coda.io/d/_dvqLrCX1frS/Dev-Environment-Commonly-Used-Commands_su6Uc#_luM2o


Note: if you don't provide the arg you will see a warning on the first line of output when running docker-compose

- mhoffman@mhoffman-Precision-3571:~/work/bedrock/platform$ docker-compose up --build
WARNING: The HOST_UID variable is not set. Defaulting to a blank string.
