### PR TITLE
fixed host user id arg syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN apt-get update \
 
 # The host machine must have a user with the uid used here, therefore the uid should be
 # provided as an arg.  Default is uid 1000.
-ARG hostUserId
-RUN if [ "$hostUserId" = "" ] ; then useradd --create-home --user-group --uid 1000 node ; else useradd --create-home --user-group --uid $hostUserId node ; fi
+ARG hostUserId=1000
+RUN useradd --create-home --user-group --uid ${hostUserId} node
 
 USER node
 RUN mkdir -p /home/node/.cache


### PR DESCRIPTION
This solves a permission denied issue when running docker-compose with the HOST_UID env variable set, the same error I was seeing a while back that I thought we fixed.  I ran into it again after doing an OS update and an OS restart.