### PR TITLE
Added outcome to game_processed

### DIFF
--- a/diplomacy/engine/game.py
+++ b/diplomacy/engine/game.py
@@ -1642,6 +1642,8 @@ class Game(Jsonable):
         state = {}
         state['timestamp'] = common.timestamp_microseconds()
         state['zobrist_hash'] = self.get_hash()
+        # Bedrock edits: want outcome of game
+        state['outcome'] = self.outcome
         state['note'] = self.note
         state['name'] = self._phase_abbr()
         state['units'] = {}


### PR DESCRIPTION
This exposes the outcome array value in the game_processed message already being sent as an unprompted message.

e.g. 
[
  'W2000A',  'AUSTRIA',
  'ENGLAND', 'FRANCE',
  'GERMANY', 'ITALY',
  'RUSSIA',  'TURKEY'
]